### PR TITLE
Support multiple meshes

### DIFF
--- a/src/gl_depth_sim/mesh_loader.cpp
+++ b/src/gl_depth_sim/mesh_loader.cpp
@@ -11,36 +11,35 @@ static std::unique_ptr<gl_depth_sim::Mesh> process(const aiScene* scene)
   const int num_meshes = scene->mNumMeshes;
   std::cout << "Scene has " << num_meshes << " meshes\n";
 
-  if (num_meshes != 1)
-  {
-    std::cerr << "Scene must have 1 mesh";
-    return {};
-  }
 
   gl_depth_sim::EigenAlignedVec<Eigen::Vector3f> vertices;
   std::vector<unsigned> indices;
 
-  const aiMesh* mesh = scene->mMeshes[0];
 
-  const int nface = mesh->mNumFaces;
-  const int nvert = mesh->mNumVertices;
+  for(int meshNum = 0 ; meshNum <num_meshes ; meshNum++)
+  {
+    const aiMesh* mesh = scene->mMeshes[meshNum];
+
+    const int nface = mesh->mNumFaces;
+    const int nvert = mesh->mNumVertices;
   std::cout << "Mesh has n faces/verts: " << nface << "/" << nvert << "\n";
 
   for (int i = 0; i < nvert; ++i)
   {
     const aiVector3D& v =  mesh->mVertices[i];
-    vertices.push_back({v.x, v.y, v.z});
-  }
+      vertices.push_back({v.x, v.y, v.z});
+    }
 
-  for (int i = 0; i < nface; ++i)
-  {
-    const aiFace& f = mesh->mFaces[i];
+    for (int i = 0; i < nface; ++i)
+    {
+      const aiFace& f = mesh->mFaces[i];
     assert(f.mNumIndices == 3);
-    indices.push_back(f.mIndices[0]);
-    indices.push_back(f.mIndices[1]);
-    indices.push_back(f.mIndices[2]);
-  }
+        indices.push_back(f.mIndices[0]);
+        indices.push_back(f.mIndices[1]);
+        indices.push_back(f.mIndices[2]);
+      }
 
+  }
   return std::unique_ptr<gl_depth_sim::Mesh>(new gl_depth_sim::Mesh(vertices, indices));
 }
 

--- a/src/gl_depth_sim/mesh_loader.cpp
+++ b/src/gl_depth_sim/mesh_loader.cpp
@@ -15,7 +15,7 @@ static std::unique_ptr<gl_depth_sim::Mesh> process(const aiScene* scene)
   gl_depth_sim::EigenAlignedVec<Eigen::Vector3f> vertices;
   std::vector<unsigned> indices;
 
-
+  long index_offset = 0;
   for(int meshNum = 0 ; meshNum <num_meshes ; meshNum++)
   {
     const aiMesh* mesh = scene->mMeshes[meshNum];
@@ -35,15 +35,19 @@ static std::unique_ptr<gl_depth_sim::Mesh> process(const aiScene* scene)
     {
       const aiFace& f = mesh->mFaces[i];
 
-      if( f.mNumIndices == 3 ){
-        indices.push_back(f.mIndices[0]);
-        indices.push_back(f.mIndices[1]);
-        indices.push_back(f.mIndices[2]);
+      if(f.mNumIndices == 3)
+      {
+        indices.push_back(f.mIndices[0] + index_offset);
+        indices.push_back(f.mIndices[1] + index_offset);
+        indices.push_back(f.mIndices[2] + index_offset);
       }
       else skippedFaces += 1;
     }
-    if (skippedFaces >0) std::cout << "Warning: Skipped " << skippedFaces << " malformed faces. \n";
-
+    if(skippedFaces > 0)
+    {
+      std::cout << "Warning: Skipped " << skippedFaces << " malformed faces. \n";
+    }
+    index_offset += nvert;
   }
   return std::unique_ptr<gl_depth_sim::Mesh>(new gl_depth_sim::Mesh(vertices, indices));
 }

--- a/src/gl_depth_sim/mesh_loader.cpp
+++ b/src/gl_depth_sim/mesh_loader.cpp
@@ -22,22 +22,27 @@ static std::unique_ptr<gl_depth_sim::Mesh> process(const aiScene* scene)
 
     const int nface = mesh->mNumFaces;
     const int nvert = mesh->mNumVertices;
-  std::cout << "Mesh has n faces/verts: " << nface << "/" << nvert << "\n";
+    std::cout << "Mesh has n faces/verts: " << nface << "/" << nvert << "\n";
 
-  for (int i = 0; i < nvert; ++i)
-  {
-    const aiVector3D& v =  mesh->mVertices[i];
+    for (int i = 0; i < nvert; ++i)
+    {
+      const aiVector3D& v =  mesh->mVertices[i];
       vertices.push_back({v.x, v.y, v.z});
     }
 
+    int skippedFaces = 0;
     for (int i = 0; i < nface; ++i)
     {
       const aiFace& f = mesh->mFaces[i];
-    assert(f.mNumIndices == 3);
+
+      if( f.mNumIndices == 3 ){
         indices.push_back(f.mIndices[0]);
         indices.push_back(f.mIndices[1]);
         indices.push_back(f.mIndices[2]);
       }
+      else skippedFaces += 1;
+    }
+    if (skippedFaces >0) std::cout << "Warning: Skipped " << skippedFaces << " malformed faces. \n";
 
   }
   return std::unique_ptr<gl_depth_sim::Mesh>(new gl_depth_sim::Mesh(vertices, indices));


### PR DESCRIPTION
In process, loop through all the meshes in a scene and add them as one combined mesh. 

Also changed the assert to an if statement to skip faces without 3 indices. Adds a counter to count the number of skipped faces in a mesh.