### PR TITLE
Add move mesh function

### DIFF
--- a/include/gl_depth_sim/sim_depth_camera.h
+++ b/include/gl_depth_sim/sim_depth_camera.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <vector>
+#include <map>
 
 // Foward declare GLFWWindow
 struct GLFWwindow;
@@ -21,7 +22,7 @@ namespace gl_depth_sim
 struct RenderableObjectState
 {
   std::unique_ptr<RenderableMesh> mesh;
-  Eigen::Affine3d pose;
+  Eigen::Isometry3d pose;
 };
 
 /**
@@ -56,7 +57,13 @@ public:
   /**
    * @brief Adds a triangle mesh to the scene with the given pose in world coordinates.
    */
+  bool add(const std::string mesh_id, const Mesh& mesh, const Eigen::Isometry3d& pose);
   bool add(const Mesh& mesh, const Eigen::Isometry3d& pose);
+
+  /**
+   * @brief Moves a triangle mesh within the scene given an identifier string and a pose in world coordinates.
+   */
+  bool move(const std::string mesh_id, const Eigen::Isometry3d& pose);
 
 private:
   void initGLFW();
@@ -69,7 +76,7 @@ private:
   // State information
   CameraProperties camera_;
   Eigen::Matrix4d proj_;
-  std::vector<RenderableObjectState> objects_;
+  std::map<std::string, RenderableObjectState> objects_;
 
   // OpenGL context info
   GLFWwindow* window_;

--- a/src/camera_orbit_example.cpp
+++ b/src/camera_orbit_example.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
 
   // Create the simulation
   gl_depth_sim::SimDepthCamera sim (props);
-  sim.add(*mesh_ptr, Eigen::Isometry3d::Identity());
+  sim.add("mesh_identifier", *mesh_ptr, Eigen::Isometry3d::Identity());
 
   // Spawn a thread to listen for the user to interact with the scene
   std::atomic<bool> thread_done (false);

--- a/src/camera_ros_example.cpp
+++ b/src/camera_ros_example.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv)
 
   // Create the simulation
   gl_depth_sim::SimDepthCamera sim (props);
-  sim.add(*mesh_ptr, Eigen::Isometry3d::Identity());
+  sim.add("mesh_identifier", *mesh_ptr, Eigen::Isometry3d::Identity());
 
 
   // State for FPS monitoring

--- a/src/usage_example.cpp
+++ b/src/usage_example.cpp
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  sim.add(*mesh_ptr, Eigen::Isometry3d::Identity());
+  sim.add("mesh_identifier", *mesh_ptr, Eigen::Isometry3d::Identity());
 
   std::cout << "Camera is looking down the positive x axis\n";
   std::cout << "Enter 'q' and press enter to quit\n";


### PR DESCRIPTION
Adds a new string identifier argument to the SimDepthCamera::add. This can then be used to move the associated mesh.