### PR TITLE
Change license tag in package.xml to match LGPLv3 license in LICENSE.txt

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="Jmeyer1292@gmail.com">Jonathan Meyer</maintainer>
 
-  <license>GPLv3</license>
+  <license>LGPLv3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>


### PR DESCRIPTION
`LICENSE.txt` contains the LGPLv3 license, but the license tag in `package.xml` is for GPLv3. I edited `package.xml` to say that the license is `LGPLv3`, under the assumptions that `LICENSE.txt` takes precedence, and that this was the intention of the original author.

An extremely classic single-character PR!