### PR TITLE
remove c++ standard from compile options and define separately to compile with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(gl_depth_sim)
 
-add_compile_options(-std=c++14 -Wall -Wextra)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_compile_options(-Wall -Wextra)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp # Used for ROS examples


### PR DESCRIPTION
When building with clang I ran into an issue with the specified compile options. 
gcc throws a warning for this, but clang throws an error. 

building with gcc:
`cc1: warning: command line option ‘-std=c++14’ is valid for C++/ObjC++ but not for C`

building with clang:
`error: invalid argument '-std=c++14' not allowed with 'C'`

By defining the c++ standard outside of compile options this warning/error is addressed and I can compile with both clang and gcc.